### PR TITLE
Update OpenWebUI env variable

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -7,7 +7,7 @@ app = ''               # change this before deploying!
 primary_region = 'ord'
 
 [env]
-OLLAMA_API_BASE_URL = 'http://localhost:11434/api'
+OLLAMA_BASE_URL = 'http://localhost:11434'
 OLLAMA_MODELS = '/app/backend/data/models'
 
 [[mounts]]


### PR DESCRIPTION
The env variables for open web ui have been updated; this change stops the "Ollama Base URL" in the UI from being set incorrectly on deploy and restart.

Discussed with OpenWebUI devs on discord and this was the recommended solution. Worked for me on deploy.