### PR TITLE
Pull a default model on start

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,7 @@ app = ''               # change this before deploying!
 primary_region = 'ord'
 
 [env]
+DEFAULT_MODEL = 'llama3.1:8b'
 OLLAMA_BASE_URL = 'http://localhost:11434'
 OLLAMA_MODELS = '/app/backend/data/models'
 

--- a/start.sh
+++ b/start.sh
@@ -4,6 +4,17 @@ mkdir -p /app/backend/data/models
 
 /bin/ollama serve &
 
+# Wait until Ollama service is up and running
+until curl -s http://localhost:11434 > /dev/null; do 
+  echo 'Waiting for Ollama service to start...'; 
+  sleep 1; 
+done 
+
+if ! [ -e "$DEFAULT_MODEL" ]; then
+  echo "Pulling default model: $DEFAULT_MODEL"
+  ollama pull $DEFAULT_MODEL &
+fi
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR" || exit
 


### PR DESCRIPTION
This pull request adds a default model environment variable to `fly.toml` and modifies `start.sh` to pull that model automatically. That way when a user first launches the web ui there's already a model in place for tinkering around. 