### PR TITLE
Fix missing git repo and ASGI error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ FROM ghcr.io/open-webui/open-webui:latest
 
 COPY --from=ollama / /
 
+RUN apt-get update && apt-get install -y git
+
 WORKDIR /app/backend
 
 COPY start.sh ./

--- a/start.sh
+++ b/start.sh
@@ -34,4 +34,4 @@ if test "$WEBUI_SECRET_KEY $WEBUI_JWT_SECRET_KEY" = " "; then
   WEBUI_SECRET_KEY=`cat $KEY_FILE`
 fi
 
-WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn main:app --host 0.0.0.0 --port 8080 --forwarded-allow-ips '*'
+WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn open_webui.main:app --host 0.0.0.0 --port 8080 --forwarded-allow-ips '*'

--- a/start.sh
+++ b/start.sh
@@ -34,4 +34,9 @@ if test "$WEBUI_SECRET_KEY $WEBUI_JWT_SECRET_KEY" = " "; then
   WEBUI_SECRET_KEY=`cat $KEY_FILE`
 fi
 
+git init /app/backend
+git -C /app/backend config user.email "ollama@example.com"
+git -C /app/backend config user.name "Ollama McLlamaface"
+git -C /app/backend commit --allow-empty -m "Initial commit"
+
 WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn open_webui.main:app --host 0.0.0.0 --port 8080 --forwarded-allow-ips '*'


### PR DESCRIPTION
Greetings!

I tried to run the one-liner yesterday (with great excitement and fanfare) and encountered two errors. The launch/deploy was successful but the app would throw the error and cause the fly machine to shut down.

Perhaps these are upstream issues to be handled by OpenWebUI? I'm not familiar enough with that image to say. Therefore I wanted to open this PR in case anybody is likewise blocked and/or these are worth merging. 

Thank you!

## Git Error

I encountered the following:

```
2024-10-03T14:12:33.052 app[568339e2b6de08] ord [info] File "/usr/local/lib/python3.11/site-packages/main.py", line 16, in <module>
2024-10-03T14:12:33.052 app[568339e2b6de08] ord [info] gitpython = GitPython()
2024-10-03T14:12:33.052 app[568339e2b6de08] ord [info] ^^^^^^^^^^^
2024-10-03T14:12:33.052 app[568339e2b6de08] ord [info] File "/usr/local/lib/python3.11/site-packages/main.py", line 8, in __init__
2024-10-03T14:12:33.052 app[568339e2b6de08] ord [info] self.repo = Repo(".")
2024-10-03T14:12:33.052 app[568339e2b6de08] ord [info] ^^^^^^^^^
2024-10-03T14:12:33.052 app[568339e2b6de08] ord [info] File "/usr/local/lib/python3.11/site-packages/git/repo/base.py", line 289, in __init__
2024-10-03T14:12:33.052 app[568339e2b6de08] ord [info] raise InvalidGitRepositoryError(epath)
2024-10-03T14:12:33.052 app[568339e2b6de08] ord [info] git.exc.InvalidGitRepositoryError: /app/backend
2024-10-03T14:12:33.764 app[568339e2b6de08] ord [info] INFO Main child exited normally with code: 1
2024-10-03T14:12:33.784 app[568339e2b6de08] ord [info] INFO Starting clean up.
2024-10-03T14:12:33.954 app[568339e2b6de08] ord [info] INFO Umounting /dev/vdc from /app/backend/data
2024-10-03T14:12:34.009 app[568339e2b6de08] ord [info] WARN could not unmount /rootfs: EINVAL: Invalid argument
2024-10-03T14:12:34.014 app[568339e2b6de08] ord [info] [ 6.185248] reboot: Power down
```

It looks like the upstream Open WebUI image expected a git binary and repo?

## ASGI Error

After fixing the git error I encountered the following:

```
2024-10-03T14:24:44.567 app[568339e2b6de08] ord [info] Loading WEBUI_SECRET_KEY from .webui_secret_key
2024-10-03T14:24:44.574 app[568339e2b6de08] ord [info] [GIN] 2024/10/03 - 14:24:44 | 200 | 29.94µs | 127.0.0.1 | HEAD "/"
2024-10-03T14:24:44.576 app[568339e2b6de08] ord [info] Reinitialized existing Git repository in /app/backend/.git/
2024-10-03T14:24:44.588 app[568339e2b6de08] ord [info] [master e0c1e37] Initial commit
2024-10-03T14:24:44.910 app[568339e2b6de08] ord [info] pulling manifest ⠋ pulling manifest ⠙ pulling manifest ⠹ ERROR: Error loading ASGI app. Attribute "app" not found in module "main".
2024-10-03T14:24:45.542 app[568339e2b6de08] ord [info] INFO Main child exited normally with code: 1
2024-10-03T14:24:45.557 app[568339e2b6de08] ord [info] INFO Starting clean up.
2024-10-03T14:24:45.841 app[568339e2b6de08] ord [info] INFO Umounting /dev/vdc from /app/backend/data
2024-10-03T14:24:45.847 app[568339e2b6de08] ord [info] WARN could not unmount /rootfs: EINVAL: Invalid argument
2024-10-03T14:24:45.851 app[568339e2b6de08] ord [info] [ 6.188454] reboot: Power down
```

`uvicorn` couldn't find the `main.py` as it was nested in the `open_webui` package.