### PR TITLE
Fix InvalidGitRepositoryError

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -34,4 +34,4 @@ if test "$WEBUI_SECRET_KEY $WEBUI_JWT_SECRET_KEY" = " "; then
   WEBUI_SECRET_KEY=`cat $KEY_FILE`
 fi
 
-WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn main:app --host 0.0.0.0 --port 8080 --forwarded-allow-ips '*'
+WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn open_webui.main:app --host 0.0.0.0 --port 8080 --forwarded-allow-ips '*'


### PR DESCRIPTION
Deploying the existing project outside of a git repo (`rm -rf .git`) results in the `InvalidGitRepositoryError` error below. This is because we run `uvicorn main:app`, which tries to load `/usr/local/lib/python3.11/site-packages/main.py` before `open_webui/main.py`. For some reason, the former tries to load a git repo via GitPython. The fix is to specify which `main.py` we want to load.

This PR can replace #3. 

```
File "/usr/local/bin/uvicorn", line 10, in <module>
  sys.exit(main())
           ^^^^^^
File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1161, in __call__
  return self.main(*args, **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1082, in main
  rv = self.invoke(ctx)
       ^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1443, in invoke
  return ctx.invoke(self.callback, **ctx.params)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/click/core.py", line 788, in invoke
  return __callback(*args, **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/uvicorn/main.py", line 410, in main
  run(
File "/usr/local/lib/python3.11/site-packages/uvicorn/main.py", line 577, in run
  server.run()
File "/usr/local/lib/python3.11/site-packages/uvicorn/server.py", line 65, in run
  return asyncio.run(self.serve(sockets=sockets))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/asyncio/runners.py", line 190, in run
  return runner.run(main)
         ^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/asyncio/runners.py", line 118, in run
  return self._loop.run_until_complete(task)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
File "/usr/local/lib/python3.11/site-packages/uvicorn/server.py", line 69, in serve
  await self._serve(sockets)
File "/usr/local/lib/python3.11/site-packages/uvicorn/server.py", line 76, in _serve
  config.load()
File "/usr/local/lib/python3.11/site-packages/uvicorn/config.py", line 434, in load
  self.loaded_app = import_from_string(self.app)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/uvicorn/importer.py", line 19, in import_from_string
  module = importlib.import_module(module_str)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
  return _bootstrap._gcd_import(name[level:], package, level)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
File "<frozen importlib._bootstrap_external>", line 940, in exec_module
File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
File "/usr/local/lib/python3.11/site-packages/main.py", line 16, in <module>
  gitpython = GitPython()
              ^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/main.py", line 8, in __init__
  self.repo = Repo(".")
              ^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/git/repo/base.py", line 289, in __init__
  raise InvalidGitRepositoryError(epath)

```